### PR TITLE
Removed owner as a property of drafts; it is now passed when `paste()…

### DIFF
--- a/Pastes/AbstractPaste.php
+++ b/Pastes/AbstractPaste.php
@@ -3,7 +3,6 @@
 namespace Brush\Pastes {
 
 	use \Brush\Accounts\Developer;
-	use \Brush\Accounts\Account;
 	use \Brush\Pastes\Options\Format;
 	use \Brush\Pastes\Options\Visibility;
 	use \Brush\Exceptions\ValidationException;
@@ -41,13 +40,6 @@ namespace Brush\Pastes {
 		 * @var int
 		 */
 		private $visibility;
-
-		/**
-		 * The account that owns this paste.
-		 * This is required if the visibility of this paste is private.
-		 * @var \Brush\Accounts\Account
-		 */
-		private $owner;
 
 		/**
 		 * Retrieve the name of this paste.
@@ -114,31 +106,6 @@ namespace Brush\Pastes {
 		}
 
 		/**
-		 * Retrieve the account that owns this paste.
-		 * @return \Brush\Accounts\Account The account that owns this paste.
-		 */
-		public final function getOwner() {
-			return $this->owner;
-		}
-
-		/**
-		 * Find whether this paste has an owner set.
-		 * If it doesn't, it cannot have private visibility.
-		 * @return boolean True if this paste has an assigned owner; false otherwise.
-		 */
-		public final function hasOwner() {
-			return $this->getOwner() !== null;
-		}
-
-		/**
-		 * Set the account that owns this paste.
-		 * @param \Brush\Accounts\Account $owner The account that owns this paste.
-		 */
-		public final function setOwner(Account $owner) {
-			$this->owner = $owner;
-		}
-
-		/**
 		 * Initialise properties to defaults.
 		 */
 		protected function __construct() {
@@ -179,9 +146,6 @@ namespace Brush\Pastes {
 			$variables->set('api_paste_code', $this->getContent());
 			$variables->set('api_paste_private', $this->getVisibility());
 			$this->getFormat()->addTo($request);
-			if ($this->hasOwner()) {
-				$this->getOwner()->sign($request, $developer);
-			}
 		}
 	}
 }

--- a/Pastes/Paste.php
+++ b/Pastes/Paste.php
@@ -58,6 +58,13 @@ namespace Brush\Pastes {
 		private $expires;
 
 		/**
+		 * The account that owns this paste.
+		 * This is required if the visibility of this paste is private.
+		 * @var \Brush\Accounts\Account
+		 */
+		private $owner;
+
+		/**
 		 * Retrieve the unique ID of this paste.
 		 * @return string The unique ID of this paste.
 		 */
@@ -177,6 +184,31 @@ namespace Brush\Pastes {
 		}
 
 		/**
+		 * Retrieve the account that owns this paste.
+		 * @return \Brush\Accounts\Account The account that owns this paste.
+		 */
+		public final function getOwner() {
+			return $this->owner;
+		}
+
+		/**
+		 * Find whether this paste has an owner set.
+		 * If it doesn't, it cannot have private visibility.
+		 * @return boolean True if this paste has an assigned owner; false otherwise.
+		 */
+		public final function hasOwner() {
+			return $this->getOwner() !== null;
+		}
+
+		/**
+		 * Set the account that owns this paste.
+		 * @param \Brush\Accounts\Account $owner The account that owns this paste.
+		 */
+		private final function setOwner(Account $owner) {
+			$this->owner = $owner;
+		}
+
+		/**
 		 * Direct outside initialisation of this class is prohibited.
 		 */
 		protected function __construct() {}
@@ -258,9 +290,10 @@ namespace Brush\Pastes {
 		 * Create a paste instance from a key and draft.
 		 * @param string $url The URL of the paste.
 		 * @param \Brush\Pastes\Draft $draft The draft to import.
+		 * @param \Brush\Accounts\Account $owner The owner of the new paste. Omit if anonymous.
 		 * @return \Brush\Pastes\Paste The created paste.
 		 */
-		public static function fromPasted($url, Draft $draft) {
+		public static function fromPasted($url, Draft $draft, Account $owner = null) {
 			$paste = new Paste();
 			$paste->import($draft);
 			$paste->setUrl($url);
@@ -269,6 +302,10 @@ namespace Brush\Pastes {
 
 			$offset = Expiry::getOffset($draft->getExpiry());
 			$paste->setExpires($offset == 0 ? 0 : $paste->getDate() + $offset);
+
+			if ($owner !== null) {
+				$paste->setOwner($owner);
+			}
 
 			return $paste;
 		}
@@ -283,10 +320,6 @@ namespace Brush\Pastes {
 			$this->setSize(strlen($draft->getContent()));
 			$this->setFormat($draft->getFormat());
 			$this->setVisibility($draft->getVisibility());
-
-			if ($draft->hasOwner()) {
-				$this->setOwner($draft->getOwner());
-			}
 		}
 
 		/**


### PR DESCRIPTION

https://github.com/geb
https://github.com/gebn/Brushn…`ing the draft to Pastebin.